### PR TITLE
Investigate missing density drawer modal failure

### DIFF
--- a/app/blueprints/production_planning/routes.py
+++ b/app/blueprints/production_planning/routes.py
@@ -238,7 +238,9 @@ def check_stock():
             "all_ok": all_ok,
             "recipe_name": recipe.name,
             "success": result.get('success', False),
-            "error": result.get('error')
+            "error": result.get('error'),
+            # Bubble any drawer instructions to the frontend for DrawerProtocol
+            "drawer_payload": result.get('drawer_payload')
         }), 200
     except Exception as e:
         logger.error(f"Error in recipe stock check: {e}")

--- a/app/services/stock_check/core.py
+++ b/app/services/stock_check/core.py
@@ -209,6 +209,7 @@ class UniversalStockCheckService:
             all_available = not (has_insufficient or has_errors)
             
             response = {
+                'success': True,
                 'status': overall_status,
                 'all_ok': all_available,
                 'stock_check': stock_results,


### PR DESCRIPTION
Enable the density modal to open by passing the `drawer_payload` in the stock check API response and ensuring the service returns `success: True`.

The frontend's `DrawerInterceptor` was not receiving the necessary `drawer_payload` because the stock check API route was not including it in its response. Additionally, the stock check service was not explicitly setting `success: True` on normal completion, which could lead to misinterpretation of the stock check status by the route.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8abfcee-7db9-412a-9756-2ad73228b179">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8abfcee-7db9-412a-9756-2ad73228b179">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

