### PR TITLE
Fix inventory density save and modal logic

### DIFF
--- a/app/blueprints/api/drawer_actions.py
+++ b/app/blueprints/api/drawer_actions.py
@@ -31,9 +31,22 @@ def conversion_density_modal_get(ingredient_id):
         # Ensure CSRF token is available in modal
         from flask_wtf.csrf import generate_csrf
         csrf_token = generate_csrf()
-        
-        modal_html = render_template('components/drawer/density_fix_modal.html',
-                                   ingredient=ingredient)
+
+        # Load categories for current organization to populate the selector
+        try:
+            from app.models.category import IngredientCategory
+            categories = IngredientCategory.query
+            if current_user.organization_id:
+                categories = categories.filter_by(organization_id=current_user.organization_id)
+            categories = categories.order_by(IngredientCategory.name).all()
+        except Exception:
+            categories = []
+
+        modal_html = render_template(
+            'components/drawer/density_fix_modal.html',
+            ingredient=ingredient,
+            categories=categories
+        )
 
         return jsonify({
             'success': True,

--- a/app/services/inventory_adjustment/_edit_logic.py
+++ b/app/services/inventory_adjustment/_edit_logic.py
@@ -91,11 +91,19 @@ def update_inventory_item(item_id: int, form_data: dict) -> tuple[bool, str]:
             except (ValueError, TypeError):
                 return False, "Invalid cost per unit value"
 
-        if 'category_id' in form_data and form_data['category_id']:
-            try:
-                item.category_id = int(form_data['category_id'])
-            except (ValueError, TypeError):
-                return False, "Invalid category ID"
+        # Handle category selection and clearing
+        if 'category_id' in form_data:
+            raw_category = form_data.get('category_id')
+            if raw_category in [None, '', 'null']:
+                # Custom category selected: clear category and allow manual density
+                item.category_id = None
+            else:
+                try:
+                    item.category_id = int(raw_category)
+                    # When a category is selected, always clear manual density to use category default
+                    item.density = None
+                except (ValueError, TypeError):
+                    return False, "Invalid category ID"
 
         if 'low_stock_threshold' in form_data:
             try:

--- a/app/templates/components/drawer/density_fix_modal.html
+++ b/app/templates/components/drawer/density_fix_modal.html
@@ -18,6 +18,19 @@
                 <form id="densityFixForm">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="mb-3">
+                        <label for="drawerCategorySelect" class="form-label">Ingredient Category</label>
+                        <select class="form-select" id="drawerCategorySelect" name="category_id">
+                            <option value="" {% if not ingredient.category_id %}selected{% endif %}>-- Custom Category --</option>
+                            {% for category in categories %}
+                            <option value="{{ category.id }}" {% if ingredient.category_id == category.id %}selected{% endif %}
+                                    data-density="{{ category.default_density }}">
+                                {{ category.name }}{% if category.default_density is not none %} (Density: {{ category.default_density }} g/ml){% endif %}
+                            </option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Select a category to auto-fill density. Choose Custom to enter your own.</div>
+                    </div>
+                    <div class="mb-3">
                         <label for="densityInput" class="form-label">
                             Density (g/ml):
                             <small class="text-muted">How many grams per milliliter</small>
@@ -30,7 +43,8 @@
                                min="0.001" 
                                max="50"
                                placeholder="e.g., 0.96 for beeswax"
-                               required>
+                               value="{% if ingredient.density %}{{ '%.3f'|format(ingredient.density) }}{% elif ingredient.category and ingredient.category.default_density %}{{ '%.3f'|format(ingredient.category.default_density) }}{% else %}{% endif %}"
+                               {% if ingredient.category_id and (not ingredient.density) %}disabled{% endif %}>
                         <div class="form-text">
                             Common densities: Water (1.0), Oil (0.91), Honey (1.42), Beeswax (0.96)
                         </div>
@@ -67,6 +81,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const form = document.getElementById('densityFixForm');
     const saveBtn = document.getElementById('saveDensityBtn');
     const densityInput = document.getElementById('densityInput');
+    const categorySelect = document.getElementById('drawerCategorySelect');
 
     console.log('🔧 DENSITY MODAL: Elements found:', {
         modal: !!modal,
@@ -94,6 +109,25 @@ document.addEventListener('DOMContentLoaded', function() {
     if (saveBtn) {
         console.log('🔧 DENSITY MODAL: Save button found and attaching listener');
 
+        // Handle category change: auto-fill and lock density unless custom
+        if (categorySelect) {
+            categorySelect.addEventListener('change', function() {
+                const selectedValue = this.value;
+                if (selectedValue === '') {
+                    densityInput.disabled = false;
+                    densityInput.value = densityInput.value || '';
+                } else {
+                    const selectedOption = this.options[this.selectedIndex];
+                    const defaultDensity = selectedOption.dataset.density;
+                    densityInput.value = defaultDensity || '';
+                    densityInput.disabled = true;
+                }
+            });
+
+            // Trigger once on load to set initial state
+            categorySelect.dispatchEvent(new Event('change'));
+        }
+
         saveBtn.addEventListener('click', function(e) {
             e.preventDefault();
             console.log('🔧 DENSITY MODAL: Save button clicked for ingredient:', ingredientId, ingredientName);
@@ -101,14 +135,19 @@ document.addEventListener('DOMContentLoaded', function() {
             console.log('🔧 DENSITY MODAL: Input element:', densityInput);
             console.log('🔧 DENSITY MODAL: Modal element:', modal);
 
-            const density = parseFloat(densityInput.value);
+            const selectedCategoryId = categorySelect ? categorySelect.value : '';
+            const isCustomCategory = !selectedCategoryId;
+            const density = isCustomCategory ? parseFloat(densityInput.value) : parseFloat(densityInput.value || '0');
             console.log('🔧 DENSITY MODAL: Raw input value:', densityInput.value);
             console.log('🔧 DENSITY MODAL: Parsed density value:', density);
 
-            if (!density || density <= 0) {
-                console.error('🔧 DENSITY MODAL: Invalid density value');
-                alert('Please enter a valid density greater than 0');
-                return;
+            // Validate only when custom category
+            if (isCustomCategory) {
+                if (!density || density <= 0) {
+                    console.error('🔧 DENSITY MODAL: Invalid density value');
+                    alert('Please enter a valid density greater than 0');
+                    return;
+                }
             }
 
             console.log('🔧 DENSITY MODAL: Starting save process...');
@@ -120,7 +159,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Build form data for inventory edit route
             const formData = new FormData(form);
-            formData.set('density', String(density));
+            if (selectedCategoryId) {
+                formData.set('category_id', selectedCategoryId);
+                // Ensure backend uses category default; do not send density override
+                formData.delete('density');
+            } else {
+                formData.set('density', String(density));
+            }
 
             // Submit to existing inventory edit route
             const url = `/inventory/edit/${ingredientId}`;


### PR DESCRIPTION
Fix Extensity drawer modal to correctly save density by aligning UI and backend logic for category-based density selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-46356603-5e69-4dc0-9caf-6ab475ebe9d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46356603-5e69-4dc0-9caf-6ab475ebe9d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

