### PR TITLE
Fix save button in missing density drawer

### DIFF
--- a/app/templates/components/drawer/density_fix_modal.html
+++ b/app/templates/components/drawer/density_fix_modal.html
@@ -70,8 +70,9 @@
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('🔧 DENSITY MODAL: DOM loaded, checking for conflicts...');
+(function() {
+    const init = function() {
+    console.log('🔧 DENSITY MODAL: Initializing density modal (DOM ready or injected)...');
 
     // Check for modal conflicts
     const allDensityModals = document.querySelectorAll('[id*="density"], [id*="Density"]');
@@ -222,7 +223,13 @@ document.addEventListener('DOMContentLoaded', function() {
     } else {
         console.error('🔧 DENSITY MODAL: Save button not found during initialization');
     }
-});
+    };
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+})();
 
 function openDensityReference() {
     // Open the density reference data instead of unit manager


### PR DESCRIPTION
Fix the Save button in the 'Fix Missing Density' drawer by ensuring its event handler is bound immediately upon injection.

---
<a href="https://cursor.com/background-agent?bcId=bc-e83c29e8-69d5-4e52-a4f9-c49dc2af9435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e83c29e8-69d5-4e52-a4f9-c49dc2af9435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

