### PR TITLE
Fix save button for missing density modal

### DIFF
--- a/app/templates/components/drawer/density_fix_modal.html
+++ b/app/templates/components/drawer/density_fix_modal.html
@@ -138,7 +138,9 @@
 
             const selectedCategoryId = categorySelect ? categorySelect.value : '';
             const isCustomCategory = !selectedCategoryId;
-            const density = isCustomCategory ? parseFloat(densityInput.value) : parseFloat(densityInput.value || '0');
+            const selectedOption = categorySelect ? categorySelect.options[categorySelect.selectedIndex] : null;
+            const defaultDensity = selectedOption ? parseFloat(selectedOption.dataset.density || '0') : 0;
+            const density = isCustomCategory ? parseFloat(densityInput.value) : defaultDensity;
             console.log('🔧 DENSITY MODAL: Raw input value:', densityInput.value);
             console.log('🔧 DENSITY MODAL: Parsed density value:', density);
 
@@ -162,8 +164,12 @@
             const formData = new FormData(form);
             if (selectedCategoryId) {
                 formData.set('category_id', selectedCategoryId);
-                // Ensure backend uses category default; do not send density override
-                formData.delete('density');
+                // Persist category's default density to resolve zero/None edge cases
+                if (defaultDensity && defaultDensity > 0) {
+                    formData.set('density', String(defaultDensity));
+                } else {
+                    formData.delete('density');
+                }
             } else {
                 formData.set('density', String(density));
             }


### PR DESCRIPTION
Fixes the "Fix Missing Density" modal not saving the category's default density when an item's density is 0 and the input is not manually changed.

Previously, if an item had 0 density but its category had a default density, the modal would display the correct category density. However, the save action wouldn't persist this value because the input wasn't manually modified, and the form data explicitly removed the `density` field for category-based saves. This led to an inconsistent state. The fix ensures the category's default density is explicitly sent and saved in this scenario.

---
<a href="https://cursor.com/background-agent?bcId=bc-700b4c6b-61e2-4318-b0b3-5107fcf01dc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-700b4c6b-61e2-4318-b0b3-5107fcf01dc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

