### PR TITLE
Fix container storage unit mismatch

### DIFF
--- a/app/blueprints/api/routes.py
+++ b/app/blueprints/api/routes.py
@@ -119,6 +119,6 @@ def get_inventory_item(item_id):
         'global_item_id': item.global_item_id,
         'is_perishable': item.is_perishable,
         'shelf_life_days': item.shelf_life_days,
-        'storage_amount': getattr(item, 'storage_amount', None),
-        'storage_unit': getattr(item, 'storage_unit', None)
+        'capacity': getattr(item, 'capacity', None),
+        'capacity_unit': getattr(item, 'capacity_unit', None)
     })

--- a/app/blueprints/batches/finish_batch.py
+++ b/app/blueprints/batches/finish_batch.py
@@ -215,7 +215,7 @@ def _create_product_output(batch, product_id, variant_id, final_quantity, output
         # Calculate total product volume used in containers
         total_container_volume = 0
         for sku_info in container_skus:
-            # Each container holds storage_amount * number of containers
+            # Each container holds capacity * number of containers
             container_capacity = sku_info.get('container_capacity', 1)
             container_count = sku_info.get('quantity', 0)
             total_container_volume += container_capacity * container_count

--- a/app/blueprints/inventory/routes.py
+++ b/app/blueprints/inventory/routes.py
@@ -504,14 +504,10 @@ def edit_inventory(id):
         else:
             item.category_id = None
 
-        # Handle container-specific fields (accept legacy storage_* keys)
+        # Handle container-specific fields
         if item.type == 'container':
             capacity = form_data.get('capacity')
-            if capacity in [None, '', 'null']:
-                capacity = form_data.get('storage_amount')
             capacity_unit = form_data.get('capacity_unit')
-            if capacity_unit in [None, '', 'null']:
-                capacity_unit = form_data.get('storage_unit')
             logger.info(f"Container update - capacity: {capacity}, capacity_unit: {capacity_unit}")
             if capacity:
                 old_capacity = item.capacity

--- a/app/blueprints/inventory/routes.py
+++ b/app/blueprints/inventory/routes.py
@@ -504,10 +504,14 @@ def edit_inventory(id):
         else:
             item.category_id = None
 
-        # Handle container-specific fields
+        # Handle container-specific fields (accept legacy storage_* keys)
         if item.type == 'container':
             capacity = form_data.get('capacity')
+            if capacity in [None, '', 'null']:
+                capacity = form_data.get('storage_amount')
             capacity_unit = form_data.get('capacity_unit')
+            if capacity_unit in [None, '', 'null']:
+                capacity_unit = form_data.get('storage_unit')
             logger.info(f"Container update - capacity: {capacity}, capacity_unit: {capacity_unit}")
             if capacity:
                 old_capacity = item.capacity

--- a/app/blueprints/settings/routes.py
+++ b/app/blueprints/settings/routes.py
@@ -390,15 +390,11 @@ def bulk_update_containers():
             container = InventoryItem.query.get(container_data['id'])
             if container and container.type == 'container':
                 container.name = container_data['name']
-                # Accept both canonical and legacy keys
+                # Canonical keys only
                 if 'capacity' in container_data:
                     container.capacity = container_data.get('capacity')
                 if 'capacity_unit' in container_data:
                     container.capacity_unit = container_data.get('capacity_unit')
-                if 'storage_amount' in container_data and container_data.get('storage_amount') is not None:
-                    container.capacity = container_data.get('storage_amount')
-                if 'storage_unit' in container_data and container_data.get('storage_unit'):
-                    container.capacity_unit = container_data.get('storage_unit')
                 container.cost_per_unit = container_data['cost_per_unit']
                 updated_count += 1
 

--- a/app/blueprints/settings/routes.py
+++ b/app/blueprints/settings/routes.py
@@ -390,8 +390,15 @@ def bulk_update_containers():
             container = InventoryItem.query.get(container_data['id'])
             if container and container.type == 'container':
                 container.name = container_data['name']
-                container.storage_amount = container_data['storage_amount']
-                container.storage_unit = container_data['storage_unit']
+                # Accept both canonical and legacy keys
+                if 'capacity' in container_data:
+                    container.capacity = container_data.get('capacity')
+                if 'capacity_unit' in container_data:
+                    container.capacity_unit = container_data.get('capacity_unit')
+                if 'storage_amount' in container_data and container_data.get('storage_amount') is not None:
+                    container.capacity = container_data.get('storage_amount')
+                if 'storage_unit' in container_data and container_data.get('storage_unit'):
+                    container.capacity_unit = container_data.get('storage_unit')
                 container.cost_per_unit = container_data['cost_per_unit']
                 updated_count += 1
 

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -58,22 +58,7 @@ class InventoryItem(ScopedModelMixin, db.Model):
     inventory_category = db.relationship('InventoryCategory', backref='inventory_items')
     global_item = db.relationship('GlobalItem')
 
-    # Aliases for legacy fields used by routes/templates
-    @property
-    def storage_amount(self):
-        return self.capacity
-
-    @storage_amount.setter
-    def storage_amount(self, value):
-        self.capacity = value
-
-    @property
-    def storage_unit(self):
-        return self.capacity_unit
-
-    @storage_unit.setter
-    def storage_unit(self, value):
-        self.capacity_unit = value
+    # Legacy aliases removed: use capacity and capacity_unit exclusively
 
     def belongs_to_user(self):
         """Check if this record belongs to the current user's organization"""

--- a/app/seeders/test_data_seeder.py
+++ b/app/seeders/test_data_seeder.py
@@ -266,8 +266,8 @@ def seed_test_data(organization_id=None):
         item_data['quantity'] = 0.0
 
         # Add storage fields - set reasonable defaults based on item type
-        item_data['storage_amount'] = 1.0  # Default storage capacity
-        item_data['storage_unit'] = item_data['unit']  # Use same unit as item unit
+        item_data['capacity'] = 1.0  # Default container capacity
+        item_data['capacity_unit'] = item_data['unit']  # Use same unit as item unit
 
         inventory_item = InventoryItem(**item_data)
         db.session.add(inventory_item)

--- a/app/services/inventory_adjustment/_creation_logic.py
+++ b/app/services/inventory_adjustment/_creation_logic.py
@@ -118,17 +118,15 @@ def create_inventory_item(form_data, organization_id, created_by):
             ownership=('global' if global_item else 'org')
         )
 
-        # Normalize capacity fields (accept both legacy storage_* and canonical capacity*)
+        # Capacity fields (canonical only)
         try:
             raw_capacity = form_data.get('capacity')
-            if raw_capacity in [None, '', 'null']:
-                raw_capacity = form_data.get('storage_amount')
             if raw_capacity not in [None, '', 'null']:
                 new_item.capacity = float(raw_capacity)
         except (ValueError, TypeError):
             pass
 
-        cap_unit = form_data.get('capacity_unit') or form_data.get('storage_unit')
+        cap_unit = form_data.get('capacity_unit')
         if cap_unit:
             new_item.capacity_unit = cap_unit
 

--- a/app/services/inventory_adjustment/_creation_logic.py
+++ b/app/services/inventory_adjustment/_creation_logic.py
@@ -118,6 +118,24 @@ def create_inventory_item(form_data, organization_id, created_by):
             ownership=('global' if global_item else 'org')
         )
 
+        # Normalize capacity fields (accept both legacy storage_* and canonical capacity*)
+        try:
+            raw_capacity = form_data.get('capacity')
+            if raw_capacity in [None, '', 'null']:
+                raw_capacity = form_data.get('storage_amount')
+            if raw_capacity not in [None, '', 'null']:
+                new_item.capacity = float(raw_capacity)
+        except (ValueError, TypeError):
+            pass
+
+        cap_unit = form_data.get('capacity_unit') or form_data.get('storage_unit')
+        if cap_unit:
+            new_item.capacity_unit = cap_unit
+
+        # Containers are always counted by "count"; ensure unit is correct
+        if item_type == 'container':
+            new_item.unit = 'count'
+
         # Apply global item defaults after instance is created
         if global_item:
             # Density for ingredients

--- a/app/services/inventory_adjustment/_edit_logic.py
+++ b/app/services/inventory_adjustment/_edit_logic.py
@@ -91,19 +91,17 @@ def update_inventory_item(item_id: int, form_data: dict) -> tuple[bool, str]:
             # Persist the unit change on the item after converting all data
             item.unit = new_unit
 
-        # Normalize capacity fields so callers can submit either legacy or canonical keys
-        try:
-            cap_value = form_data.get('capacity')
-            if cap_value in [None, '', 'null']:
-                cap_value = form_data.get('storage_amount')
-            if cap_value not in [None, '', 'null']:
-                item.capacity = float(cap_value)
-        except (ValueError, TypeError):
-            return False, "Invalid capacity value"
+        # Capacity fields (canonical only)
+        if 'capacity' in form_data:
+            try:
+                cap_value = form_data.get('capacity')
+                if cap_value not in [None, '', 'null']:
+                    item.capacity = float(cap_value)
+            except (ValueError, TypeError):
+                return False, "Invalid capacity value"
 
-        cap_unit = form_data.get('capacity_unit') or form_data.get('storage_unit')
-        if cap_unit:
-            item.capacity_unit = cap_unit
+        if 'capacity_unit' in form_data and form_data.get('capacity_unit'):
+            item.capacity_unit = form_data.get('capacity_unit')
 
         # Update basic item details (excluding quantity)
         if 'name' in form_data and not is_global_locked:

--- a/app/services/inventory_adjustment/_edit_logic.py
+++ b/app/services/inventory_adjustment/_edit_logic.py
@@ -91,6 +91,20 @@ def update_inventory_item(item_id: int, form_data: dict) -> tuple[bool, str]:
             # Persist the unit change on the item after converting all data
             item.unit = new_unit
 
+        # Normalize capacity fields so callers can submit either legacy or canonical keys
+        try:
+            cap_value = form_data.get('capacity')
+            if cap_value in [None, '', 'null']:
+                cap_value = form_data.get('storage_amount')
+            if cap_value not in [None, '', 'null']:
+                item.capacity = float(cap_value)
+        except (ValueError, TypeError):
+            return False, "Invalid capacity value"
+
+        cap_unit = form_data.get('capacity_unit') or form_data.get('storage_unit')
+        if cap_unit:
+            item.capacity_unit = cap_unit
+
         # Update basic item details (excluding quantity)
         if 'name' in form_data and not is_global_locked:
             item.name = form_data['name'].strip()

--- a/app/services/stock_check/handlers/container_handler.py
+++ b/app/services/stock_check/handlers/container_handler.py
@@ -109,9 +109,9 @@ class ContainerHandler(BaseInventoryHandler):
                 formatted_available=self._format_quantity_display(len(available_containers), "count"),
                 conversion_details={
                     **(conversion_details or {}),
-                    'storage_capacity': storage_capacity,
-                    'storage_unit': storage_unit,
-                    'storage_capacity_in_recipe_units': storage_capacity_in_recipe_units,
+                    'capacity': storage_capacity,
+                    'capacity_unit': storage_unit,
+                    'capacity_in_recipe_units': storage_capacity_in_recipe_units,
                     'recipe_yield_needed': request.quantity_needed,
                     'recipe_yield_unit': request.unit
                 }
@@ -156,8 +156,8 @@ class ContainerHandler(BaseInventoryHandler):
             'name': container.name,
             'unit': container.unit,
             'quantity': container.quantity,
-            'storage_amount': getattr(container, 'storage_amount', 0),
-            'storage_unit': getattr(container, 'storage_unit', 'ml'),
+            'capacity': getattr(container, 'capacity', 0),
+            'capacity_unit': getattr(container, 'capacity_unit', 'ml'),
             'cost_per_unit': container.cost_per_unit,
             'type': container.type
         }
@@ -226,8 +226,8 @@ class ContainerHandler(BaseInventoryHandler):
                 status=status,
                 category=InventoryCategory.CONTAINER,
                 conversion_details={
-                    'storage_capacity': getattr(container, 'capacity', 0),
-                    'storage_unit': getattr(container, 'capacity_unit', 'ml'),
+                    'capacity': getattr(container, 'capacity', 0),
+                    'capacity_unit': getattr(container, 'capacity_unit', 'ml'),
                     'item_id': container.id,
                     'item_name': container.name,
                     'stock_qty': available_quantity

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -9,16 +9,16 @@
         containerRows.forEach(row => {
             const id = row.querySelector('input[name$="[id]"]')?.value;
             const name = row.querySelector('input[name$="[name]"]')?.value;
-            const storageAmount = row.querySelector('input[name$="[storage_amount]"]')?.value;
-            const storageUnit = row.querySelector('select[name$="[storage_unit]"]')?.value;
+            const storageAmount = row.querySelector('input[name$="[capacity]"]')?.value || row.querySelector('input[name$="[storage_amount]"]')?.value;
+            const storageUnit = row.querySelector('select[name$="[capacity_unit]"]')?.value || row.querySelector('select[name$="[storage_unit]"]')?.value;
             const costPerUnit = row.querySelector('input[name$="[cost_per_unit]"]')?.value;
 
             if (id && name) {
                 containers.push({
                     id: parseInt(id),
                     name: name.trim(),
-                    storage_amount: parseFloat(storageAmount) || 0,
-                    storage_unit: storageUnit,
+                    capacity: parseFloat(storageAmount) || 0,
+                    capacity_unit: storageUnit,
                     cost_per_unit: parseFloat(costPerUnit) || 0
                 });
             }
@@ -53,6 +53,4 @@
         }
     }
 
-    window.saveAllSettings = saveAllSettings;
-    window.saveAllContainers = saveAllContainers;
-});
+window.saveAllContainers = saveAllContainers;

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -9,8 +9,8 @@
         containerRows.forEach(row => {
             const id = row.querySelector('input[name$="[id]"]')?.value;
             const name = row.querySelector('input[name$="[name]"]')?.value;
-            const storageAmount = row.querySelector('input[name$="[capacity]"]')?.value || row.querySelector('input[name$="[storage_amount]"]')?.value;
-            const storageUnit = row.querySelector('select[name$="[capacity_unit]"]')?.value || row.querySelector('select[name$="[storage_unit]"]')?.value;
+            const storageAmount = row.querySelector('input[name$="[capacity]"]')?.value;
+            const storageUnit = row.querySelector('select[name$="[capacity_unit]"]')?.value;
             const costPerUnit = row.querySelector('input[name$="[cost_per_unit]"]')?.value;
 
             if (id && name) {

--- a/app/templates/components/batch/finish_batch_modal.html
+++ b/app/templates/components/batch/finish_batch_modal.html
@@ -186,7 +186,7 @@
                           <small class="text-muted">(includes extra)</small>
                         {% endif %}
                       </td>
-                      <td>{{ data.container.capacity or data.container.storage_amount or 0 }} {{ data.container.capacity_unit or data.container.storage_unit or 'count' }}</td>
+                      <td>{{ data.container.capacity or 0 }} {{ data.container.capacity_unit or 'count' }}</td>
                       <td>{{ data.total_used }}</td>
                       <td>
                         <input type="number"
@@ -196,7 +196,7 @@
                                min="0"
                                max="{{ data.max_available }}"
                                data-container-id="{{ container_id }}"
-                               data-container-size="{{ data.container.capacity or data.container.storage_amount or 0 }}"
+                               data-container-size="{{ data.container.capacity or 0 }}"
                                data-used-quantity="{{ data.total_used }}"
                                onchange="updateContainerSummary()">
                         <input type="hidden" name="container_type_{{ container_id }}" value="combined">
@@ -205,7 +205,7 @@
                         {% endif %}
                       </td>
                       <td class="container-capacity">
-                        {{ ((data.container.capacity or data.container.storage_amount or 0) * data.total_used) }} {{ data.container.capacity_unit or data.container.storage_unit or 'count' }}
+                        {{ ((data.container.capacity or 0) * data.total_used) }} {{ data.container.capacity_unit or 'count' }}
                       </td>
                     </tr>
                     {% endfor %}

--- a/app/templates/components/batch/finish_batch_modal.html
+++ b/app/templates/components/batch/finish_batch_modal.html
@@ -8,6 +8,7 @@
       <div class="modal-body">
         <form id="finishBatchModalForm" method="post" action="{{ url_for('batches.finish_batch.complete_batch', batch_id=batch.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div id="batchMeta" data-has-containers="{{ 'true' if (batch.containers or batch.extra_containers) else 'false' }}" style="display:none;"></div>
 
           <!-- Basic Batch Information Section -->
           <div class="basic-info-section">
@@ -185,7 +186,7 @@
                           <small class="text-muted">(includes extra)</small>
                         {% endif %}
                       </td>
-                      <td>{{ data.container.storage_amount or 0 }} {{ data.container.storage_unit or 'count' }}</td>
+                      <td>{{ data.container.capacity or data.container.storage_amount or 0 }} {{ data.container.capacity_unit or data.container.storage_unit or 'count' }}</td>
                       <td>{{ data.total_used }}</td>
                       <td>
                         <input type="number"
@@ -195,7 +196,7 @@
                                min="0"
                                max="{{ data.max_available }}"
                                data-container-id="{{ container_id }}"
-                               data-container-size="{{ data.container.storage_amount or 0 }}"
+                               data-container-size="{{ data.container.capacity or data.container.storage_amount or 0 }}"
                                data-used-quantity="{{ data.total_used }}"
                                onchange="updateContainerSummary()">
                         <input type="hidden" name="container_type_{{ container_id }}" value="combined">
@@ -204,7 +205,7 @@
                         {% endif %}
                       </td>
                       <td class="container-capacity">
-                        {{ (data.container.storage_amount or 0) * data.total_used }} {{ data.container.storage_unit or 'count' }}
+                        {{ ((data.container.capacity or data.container.storage_amount or 0) * data.total_used) }} {{ data.container.capacity_unit or data.container.storage_unit or 'count' }}
                       </td>
                     </tr>
                     {% endfor %}
@@ -348,7 +349,8 @@ function loadVariants() {
 function validateYield() {
   const finalQuantityInput = document.getElementById('final_quantity');
   const alertsContainer = document.getElementById('yield-validation-alerts');
-  const hasContainers = {{ 'true' if batch.containers or batch.extra_containers else 'false' }};
+  const batchMeta = document.getElementById('batchMeta');
+  const hasContainers = (batchMeta && batchMeta.dataset && batchMeta.dataset.hasContainers === 'true');
 
   if (!finalQuantityInput) {
     return;

--- a/app/templates/inventory/components/edit_details_modal.html
+++ b/app/templates/inventory/components/edit_details_modal.html
@@ -34,7 +34,7 @@
                      {% if item.is_perishable %}checked{% endif %}>
               <label class="form-check-label" for="is_perishable">Is Perishable</label>
             </div>
-            <div id="shelfLifeField" class="mt-2" style="{{ 'display: block;' if item.is_perishable else 'display: none;' }}">
+            <div id="shelfLifeField" class="mt-2 {{ '' if item.is_perishable else 'd-none' }}">
               <label for="shelf_life_days">Shelf Life (days)</label>
               <input type="number" class="form-control" id="shelf_life_days" name="shelf_life_days" 
                      min="1" value="{{ item.shelf_life_days or '' }}">
@@ -47,15 +47,15 @@
 
           {% if item.type == 'container' %}
           <div class="mb-3">
-            <label for="storage_amount">Storage Amount:</label>
-            <input type="number" step="0.01" name="storage_amount" value="{{ item.storage_amount }}" class="form-control" required>
+            <label for="capacity">Capacity:</label>
+            <input type="number" step="0.01" name="capacity" value="{{ item.capacity }}" class="form-control" required>
           </div>
 
           <div class="mb-3">
-            <label for="storage_unit">Storage Unit:</label>
-            <select name="storage_unit" class="form-select select2" data-unit-select required>
+            <label for="capacity_unit">Capacity Unit:</label>
+            <select name="capacity_unit" class="form-select select2" data-unit-select required>
               {% for unit in get_global_unit_list() %}
-                <option value="{{ unit.name }}" {% if unit.name == item.storage_unit %}selected{% endif %}>{{ unit.name }}</option>
+                <option value="{{ unit.name }}" {% if unit.name == item.capacity_unit %}selected{% endif %}>{{ unit.name }}</option>
               {% endfor %}
             </select>
           </div>
@@ -122,6 +122,13 @@
             <button type="submit" class="btn btn-primary" id="saveDetailsButton">Save Changes</button>
           </div>
         </form>
+          <div id="editModalMeta"
+               data-original-unit="{{ item.unit }}"
+               data-has-history="{{ 'true' if item.history|length > 0 else 'false' }}"
+               data-is-container="{{ 'true' if item.type == 'container' else 'false' }}"
+               data-item-id="{{ item.id }}"
+               data-pending-change='{{ session["pending_unit_change"]|tojson if session.get("pending_unit_change") else "" }}'
+               style="display:none;"></div>
           <div id="unitChangeWarning" style="display: none;">
               <div class="alert alert-warning">
                   Changing the unit will affect all existing inventory records.
@@ -170,8 +177,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const convertInventoryFlag = document.getElementById('convertInventoryFlag');
     const conversionChoices = document.querySelectorAll('input[name="conversion_choice"]');
     const saveButton = document.getElementById('saveDetailsButton');
-    const originalUnit = '{{ item.unit }}';
-    const hasHistory = {{ (item.history|length > 0)|lower }};
+    const metaEl = document.getElementById('editModalMeta');
+    const originalUnit = (metaEl && metaEl.dataset) ? metaEl.dataset.originalUnit : '';
+    const hasHistory = (metaEl && metaEl.dataset && metaEl.dataset.hasHistory === 'true');
 
     if (unitSelect && hasHistory) {
         unitSelect.addEventListener('change', function() {
@@ -206,7 +214,7 @@ document.addEventListener('DOMContentLoaded', function() {
         editForm.addEventListener('submit', function(e) {
             // Basic form validation
             const name = this.querySelector('input[name="name"]');
-            const type = this.querySelector('select[name="type"]');
+            const isContainer = (metaEl && metaEl.dataset && metaEl.dataset.isContainer === 'true');
 
             if (!name.value.trim()) {
                 e.preventDefault();
@@ -215,22 +223,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 return false;
             }
 
-            // For containers, validate storage fields only (unit is always 'count')
-            if (type.value === 'container') {
-                const storageAmount = this.querySelector('input[name="storage_amount"]');
-                const storageUnit = this.querySelector('select[name="storage_unit"]');
+            // For containers, validate capacity fields only (unit is always 'count')
+            if (isContainer) {
+                const capAmount = this.querySelector('input[name="capacity"]') || this.querySelector('input[name="storage_amount"]');
+                const capUnit = this.querySelector('select[name="capacity_unit"]') || this.querySelector('select[name="storage_unit"]');
 
-                if (storageAmount && !storageAmount.value) {
+                if (capAmount && !capAmount.value) {
                     e.preventDefault();
-                    alert('Storage amount is required for containers');
-                    storageAmount.focus();
+                    alert('Capacity is required for containers');
+                    capAmount.focus();
                     return false;
                 }
 
-                if (storageUnit && !storageUnit.value) {
+                if (capUnit && !capUnit.value) {
                     e.preventDefault();
-                    alert('Storage unit is required for containers');
-                    storageUnit.focus();
+                    alert('Capacity unit is required for containers');
+                    capUnit.focus();
                     return false;
                 }
             } else {
@@ -249,18 +257,22 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Handle pending unit change from session
-    {% if session.get('pending_unit_change') %}
-    const pendingChange = {{ session['pending_unit_change']|tojson }};
-    if (pendingChange && pendingChange.item_id === {{ item.id }}) {
-        unitSelect.value = pendingChange.new_unit;
-        unitChangeWarning.style.display = 'block';
-        confirmUnitChange.value = 'true';
-
-        // Trigger change event to set up handlers
-        unitSelect.dispatchEvent(new Event('change'));
+    // Handle pending unit change from session (via data attribute)
+    const pendingChangeRaw = metaEl && metaEl.dataset ? metaEl.dataset.pendingChange : '';
+    if (pendingChangeRaw) {
+        try {
+            const pendingChange = JSON.parse(pendingChangeRaw);
+            const currentItemId = metaEl && metaEl.dataset ? Number(metaEl.dataset.itemId) : null;
+            if (pendingChange && unitSelect && currentItemId && Number(pendingChange.item_id) === currentItemId) {
+                unitSelect.value = pendingChange.new_unit;
+                unitChangeWarning.style.display = 'block';
+                confirmUnitChange.value = 'true';
+                unitSelect.dispatchEvent(new Event('change'));
+            }
+        } catch (_) {
+            // ignore JSON parse errors
+        }
     }
-    {% endif %}
 
     // Type change handler
     const typeSelect = document.querySelector('select[name="type"]');

--- a/app/templates/inventory/components/edit_details_modal.html
+++ b/app/templates/inventory/components/edit_details_modal.html
@@ -225,8 +225,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // For containers, validate capacity fields only (unit is always 'count')
             if (isContainer) {
-                const capAmount = this.querySelector('input[name="capacity"]') || this.querySelector('input[name="storage_amount"]');
-                const capUnit = this.querySelector('select[name="capacity_unit"]') || this.querySelector('select[name="storage_unit"]');
+                const capAmount = this.querySelector('input[name="capacity"]');
+                const capUnit = this.querySelector('select[name="capacity_unit"]');
 
                 if (capAmount && !capAmount.value) {
                     e.preventDefault();

--- a/app/templates/inventory_list.html
+++ b/app/templates/inventory_list.html
@@ -395,8 +395,8 @@
               </button>
               <ul class="dropdown-menu p-2">
                 <li><label class="dropdown-item"><input type="checkbox" checked data-column="name"> Name</label></li>
-                <li><label class="dropdown-item"><input type="checkbox" checked data-column="storage"> Storage Amount</label></li>
-                <li><label class="dropdown-item"><input type="checkbox" checked data-column="storage_unit"> Storage Unit</label></li>
+                <li><label class="dropdown-item"><input type="checkbox" checked data-column="storage"> Capacity</label></li>
+                <li><label class="dropdown-item"><input type="checkbox" checked data-column="storage_unit"> Capacity Unit</label></li>
                 <li><label class="dropdown-item"><input type="checkbox" checked data-column="quantity"> Quantity</label></li>
                 <li><label class="dropdown-item"><input type="checkbox" checked data-column="expired"> Expired</label></li>
                 <li><label class="dropdown-item"><input type="checkbox" checked data-column="cost"> Cost/Unit</label></li>
@@ -558,8 +558,8 @@
             <thead class="table-light">
               <tr>
                 <th class="col-name">Name</th>
-                <th class="col-storage">Storage Amount</th>
-                <th class="col-storage_unit">Storage Unit</th>
+                <th class="col-storage">Capacity</th>
+                <th class="col-storage_unit">Capacity Unit</th>
                 <th class="col-quantity">Quantity in Stock</th>
                 <th class="col-expired">Expired</th>
                 <th class="col-cost">Cost/Unit</th>
@@ -576,8 +576,8 @@
                     {{ item.name }}
                   </a>
                 </td>
-                <td class="col-storage">{{ item.storage_amount or 'N/A' }}</td>
-                <td class="col-storage_unit">{{ item.storage_unit or 'N/A' }}</td>
+                <td class="col-storage">{{ item.capacity or item.storage_amount or 'N/A' }}</td>
+                <td class="col-storage_unit">{{ item.capacity_unit or item.storage_unit or 'N/A' }}</td>
                 <td class="col-quantity">
                   <span class="badge bg-{{ 'danger' if item.available_quantity == 0 else 'warning' if item.low_stock_threshold and item.available_quantity <= item.low_stock_threshold else 'success' }}">
                     {{ "%.2f"|format(item.available_quantity) }} {{ item.unit or 'count' }}

--- a/app/templates/inventory_list.html
+++ b/app/templates/inventory_list.html
@@ -576,8 +576,8 @@
                     {{ item.name }}
                   </a>
                 </td>
-                <td class="col-storage">{{ item.capacity or item.storage_amount or 'N/A' }}</td>
-                <td class="col-storage_unit">{{ item.capacity_unit or item.storage_unit or 'N/A' }}</td>
+                <td class="col-storage">{{ item.capacity or 'N/A' }}</td>
+                <td class="col-storage_unit">{{ item.capacity_unit or 'N/A' }}</td>
                 <td class="col-quantity">
                   <span class="badge bg-{{ 'danger' if item.available_quantity == 0 else 'warning' if item.low_stock_threshold and item.available_quantity <= item.low_stock_threshold else 'success' }}">
                     {{ "%.2f"|format(item.available_quantity) }} {{ item.unit or 'count' }}

--- a/app/templates/pages/recipes/recipe_form.html
+++ b/app/templates/pages/recipes/recipe_form.html
@@ -131,7 +131,7 @@
                 <select id="allowed_containers" name="allowed_containers[]" class="form-select container-select" multiple>
                     {% for container in all_ingredients if container.type == 'container' %}
                     <option value="{{ container.id }}" {% if recipe and recipe.allowed_containers and container.id in recipe.allowed_containers %}selected{% endif %}>
-                        {{ container.name }} ({{ container.storage_amount }} {{ container.storage_unit }})
+                        {{ container.name }} ({{ container.capacity }} {{ container.capacity_unit }})
                     </option>
                     {% endfor %}
                 </select>


### PR DESCRIPTION
Standardize container capacity fields to `capacity`/`capacity_unit` across the application to resolve data inconsistency and functional issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e1d9229-d5cd-4c0a-91af-d48e07f4f04c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e1d9229-d5cd-4c0a-91af-d48e07f4f04c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

