### PR TITLE
Fix inventory history table display logic

### DIFF
--- a/app/templates/inventory/components/history_table.html
+++ b/app/templates/inventory/components/history_table.html
@@ -114,50 +114,36 @@
                         {{ entry.affected_lot.fifo_code }}
                       {% elif entry.fifo_reference_id %}
                         {% set ref_entry = history|selectattr('id', 'equalto', entry.fifo_reference_id)|first %}
-                        {% if ref_entry and ref_entry.change_type == 'finished_batch' and ref_entry.batch %}
+                        {% if ref_entry and ref_entry.affected_lot and ref_entry.affected_lot.fifo_code %}
                           <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.fifo_reference_id }}">
-                            {{ ref_entry.batch.label_code }}
+                            {{ ref_entry.affected_lot.fifo_code }}
                           </a>
                         {% elif ref_entry and ref_entry.fifo_code %}
                           <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.fifo_reference_id }}">
                             {{ ref_entry.fifo_code }}
                           </a>
-                        {% elif ref_entry %}
-                          <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.fifo_reference_id }}">
-                            {{ get_change_type_prefix(ref_entry.change_type) }}-{{ int_to_base36(ref_entry.id).zfill(6) }}
-                          </a>
                         {% else %}
-                          <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.fifo_reference_id }}">
-                            {{ get_change_type_prefix('restock') }}-{{ int_to_base36(entry.fifo_reference_id).zfill(6) }}
-                          </a>
+                          -
                         {% endif %}
                       {% else %}
                         -
                       {% endif %}
                     </td>
                     <td>
-                      {% if entry.change_type == 'finished_batch' and entry.batch %}
-                        {% if entry.batch.status == 'in_progress' %}
-                          <a href="{{ url_for('batches.view_batch_in_progress', batch_identifier=entry.batch.id) }}">{{ entry.batch.label_code }}</a>
-                        {% else %}
-                          <a href="{{ url_for('batches.view_batch_record', batch_identifier=entry.batch.id) }}">{{ entry.batch.label_code }}</a>
-                        {% endif %}
-                      {% elif entry.batch %}
-                        {% if entry.batch.status == 'in_progress' %}
-                          <a href="{{ url_for('batches.view_batch_in_progress', batch_identifier=entry.batch.id) }}">{{ entry.batch.label_code }}</a>
-                        {% else %}
-                          <a href="{{ url_for('batches.view_batch_record', batch_identifier=entry.batch.id) }}">{{ entry.batch.label_code }}</a>
-                        {% endif %}
+                      {% if entry.fifo_code %}
+                        <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.id }}" class="text-decoration-none">
+                          {{ entry.fifo_code }}
+                        </a>
+                      {% elif entry.change_type == 'finished_batch' and entry.batch and entry.batch.label_code %}
+                        <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.id }}" class="text-decoration-none">
+                          {{ 'BCH-' ~ entry.batch.label_code }}
+                        </a>
+                      {% elif entry.affected_lot and entry.affected_lot.fifo_code %}
+                        <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.id }}" class="text-decoration-none">
+                          {{ entry.affected_lot.fifo_code }}
+                        </a>
                       {% else %}
-                        {% if entry.fifo_code %}
-                          <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.id }}" class="text-decoration-none">
-                            {{ entry.fifo_code }}
-                          </a>
-                        {% else %}
-                          <a href="{{ url_for('inventory.view_inventory', id=item.id) }}#entry-{{ entry.id }}" class="text-decoration-none">
-                            {{ get_change_type_prefix(entry.change_type) }}-{{ int_to_base36(entry.id).zfill(6) }}
-                          </a>
-                        {% endif %}
+                        -
                       {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
Standardize "Credited/Debited" and "FIFO ID" column displays in the inventory history table to ensure consistent use of lot and event FIFO codes.

The previous implementation in `history_table.html` used ad-hoc prefix generation and inconsistent logic for displaying batch labels versus FIFO codes, leading to confusing entries. This PR resolves these inconsistencies by strictly adhering to lot FIFO codes for "Credited/Debited" and event FIFO codes (with specific fallbacks for finished batches) for "FIFO ID", removing deprecated prefix logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb5394ae-7f67-41e1-8468-adeea7ef1fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb5394ae-7f67-41e1-8468-adeea7ef1fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

