### PR TITLE
Fix portioning data passing to batch

### DIFF
--- a/app/services/batch_service/batch_operations.py
+++ b/app/services/batch_service/batch_operations.py
@@ -82,30 +82,7 @@ class BatchOperationsService(BaseService):
                     portion_snap['bulk_yield_unit_id'] = portion_snap.get('bulk_yield_unit')
                 print(f"🔍 BATCH_SERVICE DEBUG: Created portion_snap: {portion_snap}")
             else:
-                print(f"🔍 BATCH_SERVICE DEBUG: No portioning_data provided, checking recipe for portioning info...")
-                # Check if recipe itself has portioning data
-                recipe_portioning = getattr(recipe, 'portioning_data', None)
-                if recipe_portioning:
-                    print(f"🔍 BATCH_SERVICE DEBUG: Found recipe.portioning_data: {recipe_portioning}")
-                    # Use recipe portioning data as fallback, scaled to this batch
-                    if isinstance(recipe_portioning, dict) and recipe_portioning.get('is_portioned'):
-                        try:
-                            scaled_portion_count = None
-                            if isinstance(recipe_portioning.get('portion_count'), (int, float)):
-                                scaled_portion_count = round(float(recipe_portioning.get('portion_count')) * float(scale))
-                            portion_snap = {
-                                'is_portioned': True,
-                                'portion_name': recipe_portioning.get('portion_name'),
-                                'portion_count': scaled_portion_count,
-                                # Per requirement: projected_yield becomes bulk yield of the batch
-                                'bulk_yield_quantity': float(projected_yield),
-                                'bulk_yield_unit_id': recipe_portioning.get('bulk_yield_unit_id')
-                            }
-                            print(f"🔍 BATCH_SERVICE DEBUG: Fallback portion_snap from recipe (scaled): {portion_snap}")
-                        except Exception as e:
-                            print(f"🔍 BATCH_SERVICE DEBUG: ERROR building fallback portion_snap: {e}")
-                else:
-                    print(f"🔍 BATCH_SERVICE DEBUG: No portioning data in recipe either")
+                print(f"🔍 BATCH_SERVICE DEBUG: No portioning_data provided in request; skipping recipe fallback by design.")
 
             # Create the batch
             print(f"🔍 BATCH_SERVICE DEBUG: Creating batch with portioning_data: {portion_snap}")

--- a/app/static/js/production_planning/plan_production.js
+++ b/app/static/js/production_planning/plan_production.js
@@ -6,7 +6,15 @@ import { BatchManager } from './modules/batch-management.js';
 class PlanProductionApp {
     constructor() {
         const data = window.recipeData || {};
-        this.recipe = { id: data.id, name: data.name, yield_amount: data.yield_amount, yield_unit: data.yield_unit };
+        this.recipe = {
+            id: data.id,
+            name: data.name,
+            yield_amount: data.yield_amount,
+            yield_unit: data.yield_unit,
+            // Ensure portioning data is available to BatchManager
+            portioning_data: data.portioning || null,
+            is_portioned: (data.is_portioned === true || data.is_portioned === 'true')
+        };
         this.baseYield = Number(data.yield_amount || 0);
         this.unit = data.yield_unit || 'units';
         this.scale = this._readScale();


### PR DESCRIPTION
Pass portioning data directly from planned production to batch snapshot, supporting flat payload fields and removing recipe fallback.

The previous implementation failed to pass portioning information from the planned production page to the batch snapshot, resulting in `portioning_data` being `None` in the batch. This change ensures that portioning details (is_portioned, portion_name, portion_count, bulk_yield_quantity, bulk_yield_unit_id) are correctly captured and persisted in the batch snapshot, aligning with the user's requirement for direct data transfer and avoiding nested `portioning_data` as a top-level key. The explicit removal of recipe fallback ensures that only data from the request payload is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe88941-546e-4e9c-808b-635eff3f290e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fe88941-546e-4e9c-808b-635eff3f290e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

