### PR TITLE
Clarify global item section names and stats

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -85,8 +85,14 @@ def register_middleware(app):
             selected_org_id = session.get("dev_selected_org_id")
             masquerade_org_id = session.get("masquerade_org_id")  # Support both session keys
 
-            # If no org selected, redirect to organization selection unless it's a developer-specific or auth permission page
-            if not selected_org_id and not masquerade_org_id and not (request.path.startswith("/developer/") or request.path.startswith("/auth/permissions")):
+            # If no org selected, redirect to organization selection unless it's a developer-specific,
+            # auth permission page, or a public Global Library endpoint (read-only).
+            allowed_without_org = (
+                request.path.startswith("/developer/")
+                or request.path.startswith("/auth/permissions")
+                or request.path.startswith("/global-items")
+            )
+            if not selected_org_id and not masquerade_org_id and not allowed_without_org:
                 flash("Please select an organization to view customer features.", "warning")
                 return redirect(url_for("developer.organizations"))
 

--- a/app/templates/developer/global_items.html
+++ b/app/templates/developer/global_items.html
@@ -71,7 +71,9 @@
   <tbody>
   {% for gi in items %}
     <tr>
-      <td>{{ gi.name }}</td>
+      <td>
+        <a href="#" class="gi-detail-link" data-gi-id="{{ gi.id }}">{{ gi.name }}</a>
+      </td>
       <td>
         <span class="badge bg-secondary">{{ gi.item_type }}</span>
       </td>
@@ -80,7 +82,7 @@
       <td>{{ gi.capacity or '-' }} {{ gi.capacity_unit or '' }}</td>
       <td>{{ 'Yes' if gi.default_is_perishable else 'No' }}</td>
       <td>
-      <button class="btn btn-sm btn-outline-primary" onclick="openItemDetails({{ gi.id }})">
+      <button class="btn btn-sm btn-outline-primary gi-view-btn" data-gi-id="{{ gi.id }}">
         <i class="fas fa-eye"></i> View
       </button>
       <a href="{{ url_for('developer.global_item_detail', item_id=gi.id) }}" class="btn btn-sm btn-outline-secondary ms-1">
@@ -294,12 +296,24 @@ function filterItems() {
 
 // Initialize page functionality
 document.addEventListener('DOMContentLoaded', function() {
-    try {
-        // Add any initialization code here if needed
-        console.log('Global items page loaded successfully');
-    } catch (error) {
-        console.error('Error initializing page:', error);
-    }
+  try {
+    document.querySelectorAll('.gi-detail-link').forEach(function(el){
+      el.addEventListener('click', function(e){
+        e.preventDefault();
+        const id = this.getAttribute('data-gi-id');
+        if (id) openItemDetails(id);
+      });
+    });
+    document.querySelectorAll('.gi-view-btn').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        const id = this.getAttribute('data-gi-id');
+        if (id) openItemDetails(id);
+      });
+    });
+  } catch (error) {
+    console.error('Error initializing page:', error);
+  }
 });
 </script>
 <script>

--- a/app/templates/library/global_items_public.html
+++ b/app/templates/library/global_items_public.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h2>Global Inventory Library</h2>
+  <h2>Global Item Library</h2>
   {% if is_developer() %}
   <div>
     <a href="{{ url_for('developer.reference_categories') }}" class="btn btn-outline-primary me-2">


### PR DESCRIPTION
Enable developer access to global item stats and unify the global item list interaction for developers with the customer view.

Developers previously encountered issues where the side stats card wouldn't load data and the 'View' button was unresponsive on the global item list. Additionally, the item names were not hyperlinked for developers, unlike the customer view. This PR resolves these inconsistencies by allowing developers to access public global item endpoints without an organization selected, making the names clickable, and ensuring the 'View' button correctly opens the shared detail offcanvas.

---
<a href="https://cursor.com/background-agent?bcId=bc-87b7f65e-8f82-4f13-a0f9-10947c123d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87b7f65e-8f82-4f13-a0f9-10947c123d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

