### PR TITLE
Refactor add on and tier retention logic

### DIFF
--- a/app/templates/developer/create_tier.html
+++ b/app/templates/developer/create_tier.html
@@ -45,10 +45,17 @@
                                 </div>
 
                                 <div class="mb-3">
+                                    <label for="retention_policy" class="form-label">Data Retention</label>
+                                    <select class="form-select" id="retention_policy" name="retention_policy" onchange="toggleRetentionFields()">
+                                        <option value="one_year" selected>1 year</option>
+                                        <option value="subscribed">Subscribed</option>
+                                    </select>
+                                    <div class="form-text">All-or-nothing: 1 year or unlimited while subscribed.</div>
+                                </div>
+                                <div class="mb-3" id="retention_days_field" style="display:none;">
                                     <label for="data_retention_days" class="form-label">Data Retention (days)</label>
                                     <input type="number" class="form-control" id="data_retention_days" name="data_retention_days" 
-                                           min="0" placeholder="e.g., 365 for 1 year (leave blank for indefinite)">
-                                    <div class="form-text">How long to retain long-term data before hard delete. Blank = indefinite.</div>
+                                           min="0" placeholder="365">
                                 </div>
 
                                 <div class="mb-3">
@@ -187,5 +194,23 @@ function toggleBillingFields() {
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', toggleBillingFields);
+
+function toggleRetentionFields() {
+    const policy = document.getElementById('retention_policy')?.value;
+    const daysField = document.getElementById('retention_days_field');
+    if (!policy || !daysField) return;
+    if (policy === 'one_year') {
+        daysField.style.display = 'none';
+        const input = document.getElementById('data_retention_days');
+        if (input) input.value = 365;
+    } else if (policy === 'subscribed') {
+        daysField.style.display = 'none';
+        const input = document.getElementById('data_retention_days');
+        if (input) input.value = '';
+    } else {
+        daysField.style.display = 'block';
+    }
+}
+document.addEventListener('DOMContentLoaded', toggleRetentionFields);
 </script>
 {% endblock %}

--- a/app/templates/developer/edit_tier.html
+++ b/app/templates/developer/edit_tier.html
@@ -130,6 +130,14 @@
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="mb-3">
+                                    <label for="retention_policy" class="form-label">Data Retention</label>
+                                    <select class="form-select" id="retention_policy" name="retention_policy" onchange="toggleRetentionFields()">
+                                        <option value="one_year" {{ 'selected' if tier.retention_policy == 'one_year' else '' }}>1 year</option>
+                                        <option value="subscribed" {{ 'selected' if tier.retention_policy == 'subscribed' else '' }}>Subscribed</option>
+                                    </select>
+                                    <div class="form-text">All-or-nothing policy: 1 year or unlimited while subscribed.</div>
+                                </div>
+                                <div class="mb-3" id="retention_days_field" style="display:none;">
                                     <label for="data_retention_days" class="form-label">Data Retention (days)</label>
                                     <input type="number" class="form-control" id="data_retention_days" name="data_retention_days" value="{{ tier.data_retention_days or '' }}" min="0">
                                 </div>
@@ -211,5 +219,21 @@ function toggleBillingFields() {
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', toggleBillingFields);
+
+function toggleRetentionFields() {
+    const policy = document.getElementById('retention_policy').value;
+    const daysField = document.getElementById('retention_days_field');
+    // Show legacy days field only when not strictly one_year/subscribed
+    if (policy === 'one_year') {
+        daysField.style.display = 'none';
+        document.getElementById('data_retention_days').value = 365;
+    } else if (policy === 'subscribed') {
+        daysField.style.display = 'none';
+        document.getElementById('data_retention_days').value = '';
+    } else {
+        daysField.style.display = 'block';
+    }
+}
+document.addEventListener('DOMContentLoaded', toggleRetentionFields);
 </script>
 {% endblock %}

--- a/app/templates/developer/subscription_tiers.html
+++ b/app/templates/developer/subscription_tiers.html
@@ -99,15 +99,17 @@
                             </span>
                         </div>
 
-                        {% if tier_data.data_retention_days or tier_data.retention_notice_days %}
+                        {% if tier_data.retention_policy or tier_data.data_retention_days or tier_data.retention_notice_days %}
                         <div class="d-flex align-items-center mb-2">
                             <i class="fas fa-database me-2 text-info"></i>
                             <strong>Retention:</strong>
                             <span class="ms-2">
-                                {% if tier_data.data_retention_days %}
-                                    {{ tier_data.data_retention_days }} days
+                                {% if tier_data.retention_label %}
+                                  {{ tier_data.retention_label }}
+                                {% elif tier_data.data_retention_days %}
+                                  {{ tier_data.data_retention_days }} days
                                 {% else %}
-                                    Indefinite
+                                  Indefinite
                                 {% endif %}
                                 {% if tier_data.retention_notice_days %}
                                     <small class="text-muted">(notice {{ tier_data.retention_notice_days }} days)</small>


### PR DESCRIPTION
Implement an all-or-nothing data retention policy for subscription tiers, allowing selection of "1 year" or "Subscribed" retention.

The previous retention system allowed arbitrary day inputs, which was not desired. This change simplifies the policy to either a fixed 1-year retention or indefinite retention (marked as "Subscribed"), which can be granted by the tier itself or by an active retention add-on. This aligns with the user's request for a clear, all-or-nothing approach to data retention.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e32aac6-16db-44b5-a982-ce205a198a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e32aac6-16db-44b5-a982-ce205a198a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

